### PR TITLE
Fix uninitialized constant Sandwich::Client::UUIDTools

### DIFF
--- a/lib/sandwich/client.rb
+++ b/lib/sandwich/client.rb
@@ -1,5 +1,6 @@
 require 'sandwich/cookbook_version'
 require 'chef'
+require 'uuidtools'
 
 module Sandwich
   # Chef::Client extended to inject a Sandwich cookbook into the


### PR DESCRIPTION
Fix an error

```
sandwich: uninitialized constant Sandwich::Client::UUIDTools
```