### PR TITLE
Enhance error message shown by sandwich command

### DIFF
--- a/bin/sandwich
+++ b/bin/sandwich
@@ -6,6 +6,6 @@ begin
   sandwich.run(ARGV)
 rescue SystemExit
 rescue Exception => e
-  $stderr.puts("sandwich: #{e.message}")
+  $stderr.puts("sandwich: #{e.class} #{e.message} #{e.backtrace.first}")
   exit(1)
 end


### PR DESCRIPTION
Before:

```
sandwich: uninitialized constant Sandwich::Client::UUIDTools
```

After:

```
sandwich: NameError, uninitialized constant Sandwich::Client::UUIDTools
  /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-sandwich-0.3.0/lib/sandwich/client.rb:80:in `unique_cookbook_name'
  /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-sandwich-0.3.0/lib/sandwich/client.rb:30:in `initialize'
  /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-sandwich-0.3.0/lib/sandwich/runner.rb:18:in `new'
  /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-sandwich-0.3.0/lib/sandwich/runner.rb:18:in `initialize'
  /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-sandwich-0.3.0/lib/sandwich/cli.rb:76:in `new'
  /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-sandwich-0.3.0/lib/sandwich/cli.rb:76:in `run'
  /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-sandwich-0.3.0/bin/sandwich:6:in `<top (required)>'
  /opt/chef/embedded/bin/sandwich:23:in `load'
  /opt/chef/embedded/bin/sandwich:23:in `<main>'
```
