### PR TITLE
Support segment_filenames

### DIFF
--- a/lib/sandwich/cookbook_version.rb
+++ b/lib/sandwich/cookbook_version.rb
@@ -24,8 +24,14 @@ module Sandwich
                                             segment,
                                             filename,
                                             current_filepath=nil)
-      # keep absolute paths, convert relative paths into absolute paths
-      filename.start_with?('/') ? filename : File.join(@basedir, filename)
+      segment_filenames = [
+        File.join(segment.to_s, "#{node[:platform]}-#{node[:platform_version]}", filename),
+        File.join(segment.to_s, node[:platform], filename),
+        File.join(segment.to_s, 'default', filename),
+        File.join(segment.to_s, filename),
+        File.expand_path(filename, @base_dir), # keep absolute paths, convert relative paths into absolute paths
+      ]
+      segment_filenames.find {|filename| File.exist?(filename) }
     end
   end
 end


### PR DESCRIPTION
This patch makes possible to write a recipe like

```
template "/etc/sysctl.conf" do
  source "etc/sysctl.conf.erb"
end
```

as we usually write in chef. New `preferred_filename_on_disk_location` searches files like

* tempaltes/platform-version/filename
* templates/platform/filename
* templates/default/filename
* templates/filename
* filename

as chef does (except the last line). 