### PR TITLE
Fix uninitialized constant Chef::Application

### DIFF
--- a/lib/sandwich/client.rb
+++ b/lib/sandwich/client.rb
@@ -1,5 +1,6 @@
 require 'sandwich/cookbook_version'
 require 'chef'
+require 'chef/application'
 
 module Sandwich
   # Chef::Client extended to inject a Sandwich cookbook into the


### PR DESCRIPTION
Chef::Client uses Chef::Application when an error occurs.