### PR TITLE
add --json-attributes option

### DIFF
--- a/lib/sandwich/cli.rb
+++ b/lib/sandwich/cli.rb
@@ -43,6 +43,12 @@ module Sandwich
                 'Execute command as a sandwich script') do |c|
           @options[:command] << c
         end
+
+        opts.on('-j',
+                '--json-attributes JSON_ATTRIBS',
+                'Load attributes from a JSON file or URL') do |c|
+          @options[:json_attribs] = c
+        end
       end
     end
 
@@ -70,10 +76,15 @@ module Sandwich
         end
       end
 
+      if @options[:json_attribs]
+        config_fetcher = Chef::ConfigFetcher.new(@options[:json_attribs])
+        json_attribs = config_fetcher.fetch_json
+      end
+
       # pass remaining arguments on to script
       ARGV.replace(unparsed_arguments)
 
-      runner = Sandwich::Runner.new(recipe_filename, recipe)
+      runner = Sandwich::Runner.new(recipe_filename, recipe, json_attribs)
       runner.run(@options[:log_level])
     end
   end

--- a/lib/sandwich/client.rb
+++ b/lib/sandwich/client.rb
@@ -13,9 +13,10 @@ module Sandwich
     #
     # @param [String] recipe_filename the recipe filename
     # @param [String] recipe_string the recipe definition
-    def initialize(recipe_filename, recipe_string = nil)
+    # @param [Hash]   json_attribs the JSON attributes
+    def initialize(recipe_filename, recipe_string = nil, json_attribs = nil)
       Chef::Config[:solo] = true
-      super()
+      super(json_attribs)
 
       if recipe_string
         @sandwich_basedir = Dir.getwd

--- a/lib/sandwich/runner.rb
+++ b/lib/sandwich/runner.rb
@@ -14,8 +14,9 @@ module Sandwich
     #
     # @param [String] recipe_filename the recipe filename
     # @param [String] recipe_string the recipe definition
-    def initialize(recipe_filename, recipe_string = nil)
-      @client = Sandwich::Client.new(recipe_filename, recipe_string)
+    # @param [Hash]   json_attribs the JSON attributes
+    def initialize(recipe_filename, recipe_string = nil, json_attribs = nil)
+      @client = Sandwich::Client.new(recipe_filename, recipe_string, json_attribs)
     end
 
     # Run Chef in standalone mode, apply recipe


### PR DESCRIPTION
This patch adds a json_attributes option for sandwich command which works like:

```
sandwich -j node.json recipe.rb
```

This enables us to set attributers (we could not do it before).